### PR TITLE
fix: npm install failure on node v16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ RudderStack's Control Plane Lite utility provides the UI to self-host and manage
 
 ## Setup
 
+Requirement: Use `Node.js v14` for the best experience. (`Node v16` and higher versions are not supported)
+
 To set up the RudderStack Control Plane Lite, run the following commands:
 
 1. `npm install`

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     "eject": "react-scripts eject",
     "analyze": "source-map-explorer 'build/static/js/*.js'"
   },
+  "engines": {
+    "node": "<16"
+  },
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
## Description of the change

Now the project strictly checks the node version and shows the error if node version is equal or above v16. The core issue was node-sass dependency we have, it's v4 version does not support node versions higher than node v14.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Fix #33 

## Checklists

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 